### PR TITLE
feat: AIチャットをVercel AI SDK streamTextベースのエージェントに移行

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,11 +12,13 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@ai-sdk/openai": "^3.0.48",
 		"@aws-lambda-powertools/logger": "^2.30.2",
 		"@aws-sdk/client-dynamodb": "^3.966.0",
 		"@aws-sdk/client-secrets-manager": "^3.971.0",
 		"@aws-sdk/lib-dynamodb": "^3.966.0",
 		"@hono/zod-validator": "^0.7.6",
+		"ai": "^6.0.141",
 		"aws-jwt-verify": "^5.1.1",
 		"openai": "^6.16.0"
 	},

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
 	"scripts": {
 		"build": "tsc",
 		"format:check": "biome format .",
+		"format:write": "biome format --write .",
 		"lint": "biome lint .",
 		"type-check": "tsc --noEmit",
 		"sam:build:dev": "sam build --config-env=dev",

--- a/backend/src/routes/chatRoute.ts
+++ b/backend/src/routes/chatRoute.ts
@@ -68,10 +68,7 @@ export const chatRoute = new Hono<HonoEnv>()
 				// ストリーム完了後にDB保存・タイトル生成
 				await addMessage(userId, roomId, "assistant", fullText);
 
-				const updateTitle = await openAITitleClient(
-					params.message,
-					fullText,
-				);
+				const updateTitle = await openAITitleClient(params.message, fullText);
 				await updateChatRoom(userId, roomId, updateTitle);
 			});
 		} catch (error) {

--- a/backend/src/routes/chatRoute.ts
+++ b/backend/src/routes/chatRoute.ts
@@ -1,8 +1,9 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { streamText } from "hono/streaming";
+import { streamText as honoStreamText } from "hono/streaming";
 import { ERROR_CODES, ERROR_STATUS_CODE } from "../constants/error";
 import { isAuthenticated } from "../middlewares/auth";
+import { callAgentStream } from "../services/agentService";
 import {
 	addMessage,
 	createChatRoom,
@@ -11,13 +12,10 @@ import {
 	getChatRooms,
 	updateChatRoom,
 } from "../services/chatServices";
-import { getDiaries } from "../services/diaryService";
 import type { HonoEnv } from "../types/hono";
-import { getHighCosineSimilarityItems } from "../utils/cosineSimilarity";
-import { getEmbedding } from "../utils/embeddings";
 import { toError } from "../utils/error";
 import { logger } from "../utils/logger";
-import { openAIChatClient, openAITitleClient } from "../utils/openAI";
+import { openAITitleClient } from "../utils/openAI";
 import { errorResponse, successResponse } from "../utils/response";
 import { PostChatRequestSchema } from "../validators/chat";
 import { isUuidValidateV7 } from "../validators/common";
@@ -29,20 +27,8 @@ export const chatRoute = new Hono<HonoEnv>()
 	.post("/rooms", zValidator("json", PostChatRequestSchema), async (c) => {
 		const userId = c.get("userId");
 		const params = c.req.valid("json");
+
 		try {
-			// 入力されたメッセージをベクトル化、既存の日記一覧を取得
-			const [inputEmbedding, diaries] = await Promise.all([
-				getEmbedding(params.message),
-				getDiaries(userId),
-			]);
-			if (!diaries.success) {
-				return c.json(diaries, ERROR_STATUS_CODE[diaries.error.code]);
-			}
-			// 入力されたメッセージとのコサイン類似度が高い日記を最大５つ取得
-			const highCosineSimilarityItems = getHighCosineSimilarityItems(
-				inputEmbedding,
-				diaries.data,
-			);
 			// チャットルーム新規作成
 			const resultCreateChatRoom = await createChatRoom(userId);
 			if (!resultCreateChatRoom.success) {
@@ -51,6 +37,7 @@ export const chatRoute = new Hono<HonoEnv>()
 					ERROR_STATUS_CODE[resultCreateChatRoom.error.code],
 				);
 			}
+
 			// dynamoDBにユーザーから入力されたメッセージを保存
 			const resultAddUserMessage = await addMessage(
 				userId,
@@ -64,58 +51,31 @@ export const chatRoute = new Hono<HonoEnv>()
 					ERROR_STATUS_CODE[resultAddUserMessage.error.code],
 				);
 			}
-			// OpenAIに入力されたメッセージとのコサイン類似度が高い日記（最大５つ）を送信
-			const chatStream = await openAIChatClient(
-				params.message,
-				highCosineSimilarityItems,
-			);
-			c.header("X-Room-Id", resultCreateChatRoom.data.roomId);
-			return streamText(c, async (stream) => {
-				try {
-					for await (const event of chatStream) {
-						// OpenAIがレスポンス作成中の場合はstreamに書き込む
-						if (event.type === "response.output_text.delta") {
-							await stream.write(event.delta);
-						}
-						// OpenAIのレスポンスが完了した場合はdynamoDBにOpenAIのレスポンス全体を保存してreturn
-						if (event.type === "response.output_text.done") {
-							const content = event.text;
-							// dynamoDBにOpenAIのレスポンス全体を保存
-							const resultAddOpenAIMessage = await addMessage(
-								userId,
-								resultCreateChatRoom.data.roomId,
-								"assistant",
-								content,
-							);
-							if (!resultAddOpenAIMessage.success) {
-								throw resultAddOpenAIMessage;
-							}
-							// 初回のチャットメッセージ内容からチャットルームタイトルを生成
-							const updateTitle = await openAITitleClient(
-								params.message,
-								content,
-							);
-							// チャットルームのタイトル更新
-							const resultUpdateChatRoom = await updateChatRoom(
-								userId,
-								resultCreateChatRoom.data.roomId,
-								updateTitle,
-							);
-							if (!resultUpdateChatRoom.success) {
-								throw resultUpdateChatRoom;
-							}
-							return;
-						}
-					}
-				} catch (error) {
-					logger.error("Failed to OpenAI API Request", toError(error));
-					await stream.write("エラーが発生しました。もう一度お試しください。");
-				} finally {
-					stream.close();
+
+			// ストリーミングレスポンスで返す
+			const roomId = resultCreateChatRoom.data.roomId;
+			c.header("X-Room-Id", roomId);
+
+			return honoStreamText(c, async (stream) => {
+				const result = await callAgentStream(userId, params.message);
+
+				let fullText = "";
+				for await (const textPart of result.textStream) {
+					await stream.write(textPart);
+					fullText += textPart;
 				}
+
+				// ストリーム完了後にDB保存・タイトル生成
+				await addMessage(userId, roomId, "assistant", fullText);
+
+				const updateTitle = await openAITitleClient(
+					params.message,
+					fullText,
+				);
+				await updateChatRoom(userId, roomId, updateTitle);
 			});
 		} catch (error) {
-			logger.error("Failed to initialize OpenAI client", toError(error));
+			logger.error("Failed to process chat request", toError(error));
 			return c.json(
 				errorResponse(ERROR_CODES.INTERNAL_SERVER_ERROR),
 				ERROR_STATUS_CODE[ERROR_CODES.INTERNAL_SERVER_ERROR],
@@ -137,6 +97,7 @@ export const chatRoute = new Hono<HonoEnv>()
 				);
 			}
 			const params = c.req.valid("json");
+
 			try {
 				// チャットルームが存在するか確認
 				const resultGetChatRoom = await getChatRoom(userId, roomId);
@@ -146,19 +107,7 @@ export const chatRoute = new Hono<HonoEnv>()
 						ERROR_STATUS_CODE[resultGetChatRoom.error.code],
 					);
 				}
-				// 入力されたメッセージをベクトル化、既存の日記一覧を取得
-				const [inputEmbedding, diaries] = await Promise.all([
-					getEmbedding(params.message),
-					getDiaries(userId),
-				]);
-				if (!diaries.success) {
-					return c.json(diaries, ERROR_STATUS_CODE[diaries.error.code]);
-				}
-				// 入力されたメッセージとのコサイン類似度が高い日記を最大５つ取得
-				const highCosineSimilarityItems = getHighCosineSimilarityItems(
-					inputEmbedding,
-					diaries.data,
-				);
+
 				// dynamoDBにユーザーから入力されたメッセージを保存
 				const resultAddUserMessage = await addMessage(
 					userId,
@@ -172,57 +121,23 @@ export const chatRoute = new Hono<HonoEnv>()
 						ERROR_STATUS_CODE[resultAddUserMessage.error.code],
 					);
 				}
-				// OpenAIに入力されたメッセージとのコサイン類似度が高い日記（最大５つ）を送信
-				const chatStream = await openAIChatClient(
-					params.message,
-					highCosineSimilarityItems,
-				);
-				return streamText(c, async (stream) => {
-					try {
-						for await (const event of chatStream) {
-							// OpenAIがレスポンス作成中の場合はstreamに書き込む
-							if (event.type === "response.output_text.delta") {
-								await stream.write(event.delta);
-							}
-							// OpenAIのレスポンスが完了した場合はdynamoDBにOpenAIのレスポンス全体を保存してreturn
-							if (event.type === "response.output_text.done") {
-								const content = event.text;
-								// dynamoDBにOpenAIのレスポンス全体を保存
-								const resultAddOpenAIMessage = await addMessage(
-									userId,
-									roomId,
-									"assistant",
-									content,
-								);
-								if (!resultAddOpenAIMessage.success) {
-									throw resultAddOpenAIMessage;
-								}
-								// チャットルームのupdateAtを更新
-								const resultUpdateChatRoom = await updateChatRoom(
-									userId,
-									roomId,
-								);
-								if (!resultUpdateChatRoom.success) {
-									// タイムスタンプ更新失敗は致命的ではないため、エラーにはしない
-									logger.warn("Failed to update chatRoom updatedAt", {
-										userId,
-										roomId,
-									});
-								}
-								return;
-							}
-						}
-					} catch (error) {
-						logger.error("Failed to OpenAI API Request", toError(error));
-						await stream.write(
-							"エラーが発生しました。もう一度お試しください。",
-						);
-					} finally {
-						stream.close();
+
+				// ストリーミングレスポンスで返す
+				return honoStreamText(c, async (stream) => {
+					const result = await callAgentStream(userId, params.message);
+
+					let fullText = "";
+					for await (const textPart of result.textStream) {
+						await stream.write(textPart);
+						fullText += textPart;
 					}
+
+					// ストリーム完了後にDB保存・タイムスタンプ更新
+					await addMessage(userId, roomId, "assistant", fullText);
+					await updateChatRoom(userId, roomId);
 				});
 			} catch (error) {
-				logger.error("Failed to initialize OpenAI client", toError(error));
+				logger.error("Failed to process chat request", toError(error));
 				return c.json(
 					errorResponse(ERROR_CODES.INTERNAL_SERVER_ERROR),
 					ERROR_STATUS_CODE[ERROR_CODES.INTERNAL_SERVER_ERROR],

--- a/backend/src/services/agentService.ts
+++ b/backend/src/services/agentService.ts
@@ -1,0 +1,66 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText, stepCountIs } from "ai";
+import { createDiaryTools } from "../tools/diaryTools";
+import { logger } from "../utils/logger";
+import { getSecretValue } from "../utils/secretsManager"; // ← 追加
+
+const apiKeyName = process.env.OPENAI_API_KEY_NAME;
+if (!apiKeyName) {
+	throw new Error("Environment variables OpenAIAPIKeyName must be set");
+}
+
+/**
+ * エージェントにメッセージを送信してストリーミングレスポンスを得る
+ *
+ * @param userId - ユーザーID
+ * @param message - ユーザーからのメッセージ
+ * @returns streamTextの結果オブジェクト（textStreamなどを含む）
+ */
+export const callAgentStream = async (userId: string, message: string) => {
+	logger.info("🤖 Starting agent call", { userId, message });
+
+	// AWS Secrets ManagerからAPIキーを取得
+	const apiKey = await getSecretValue(apiKeyName);
+	if (!apiKey) {
+		throw new Error(`Failed to get APIKey: ${apiKeyName}`);
+	}
+	const openai = createOpenAI({ apiKey });
+
+	// ユーザー用のツールを生成
+	const tools = createDiaryTools(userId);
+
+	// エージェントを呼び出す（streamTextはawait不要、即座にオブジェクトを返す）
+	const result = streamText({
+		model: openai("gpt-4o-mini"),
+		system:
+			"あなたはユーザーの日記を読んで、パーソナライズされた回答をするAIアシスタントです。必要に応じてツールを使ってユーザーの日記を参照してください。一般的な質問には、ツールを使わず直接回答してください。",
+		prompt: message,
+		tools,
+		toolChoice: "auto",
+		stopWhen: stepCountIs(5),
+		onStepFinish: (step) => {
+			// エージェントの各ステップをログ出力
+			logger.info("🤖 Agent step finished", {
+				stepNumber: step.stepNumber,
+				text: step.text ? step.text.substring(0, 100) : undefined,
+				toolCalls: step.toolCalls?.map((tc) => ({
+					toolCallId: tc.toolCallId,
+					toolName: tc.toolName,
+					input: tc.input,
+				})),
+				toolResults: step.toolResults?.map((tr) => ({
+					toolCallId: tr.toolCallId,
+					toolName: tr.toolName,
+					output:
+						typeof tr.output === "object"
+							? JSON.stringify(tr.output).substring(0, 200)
+							: tr.output,
+				})),
+				finishReason: step.finishReason,
+				usage: step.usage,
+			});
+		},
+	});
+
+	return result;
+};

--- a/backend/src/tools/diaryTools.ts
+++ b/backend/src/tools/diaryTools.ts
@@ -1,0 +1,116 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { getDiaries } from "../services/diaryService";
+import { getHighCosineSimilarityItems } from "../utils/cosineSimilarity";
+import { getEmbedding } from "../utils/embeddings";
+import { toError } from "../utils/error";
+import { logger } from "../utils/logger";
+
+/**
+ * ユーザーIDを受け取って、そのユーザー用のツールを生成する関数
+ */
+export const createDiaryTools = (userId: string) => {
+	return {
+		search_user_diaries: tool({
+			description:
+				"ユーザーの過去の日記から関連する内容を検索します。ユーザーの個人的な記録や過去の出来事について質問されたときに使います。例：「最近何考えてた？」「先週何食べた？」",
+			inputSchema: z.object({
+				query: z.string().describe("検索したい内容やキーワード"),
+			}),
+			execute: async ({ query }) => {
+				// userId はクロージャーでアクセス可能
+				logger.info("🤖 Agent called search_user_diaries tool", {
+					query,
+					userId,
+				});
+
+				try {
+					// 1. クエリをベクトル化
+					const inputEmbedding = await getEmbedding(query);
+
+					// 2. ユーザーの全日記を取得
+					const diariesResult = await getDiaries(userId);
+					if (!diariesResult.success) {
+						throw new Error("Failed to get user diaries");
+					}
+
+					// 3. コサイン類似度で関連日記を抽出
+					const similarDiaries = getHighCosineSimilarityItems(
+						inputEmbedding,
+						diariesResult.data,
+					);
+
+					logger.info("🤖 search_user_diaries tool result", {
+						query,
+						foundCount: similarDiaries.length,
+						similarities: similarDiaries.map((d) => d.cosineSimilarity),
+					});
+
+					// 4. エージェントが理解しやすい形式で返す
+					return {
+						count: similarDiaries.length,
+						diaries: similarDiaries.map((diary) => ({
+							date: diary.date,
+							feeling: diary.feeling || "記載なし",
+							content: diary.content,
+							similarity: Math.round(diary.cosineSimilarity * 100) / 100,
+						})),
+					};
+				} catch (error) {
+					logger.error("🤖 search_user_diaries tool error", toError(error));
+					throw error;
+				}
+			},
+		}),
+		get_recent_diaries: tool({
+			description:
+				"最近の日記を時系列で取得します。ユーザーが「最近どう？」「今週の様子は？」と聞いてきた場合に使用します。検索は使わず、単純に最新のN件を返します。",
+			inputSchema: z.object({
+				count: z
+					.number()
+					.default(5)
+					.describe("取得する日記の件数（デフォルト5件）"),
+			}),
+			execute: async ({ count }) => {
+				logger.info("🤖 Agent called get_recent_diaries tool", {
+					count,
+					userId,
+				});
+
+				try {
+					// 1. ユーザーの全日記を取得
+					const diariesResult = await getDiaries(userId);
+					if (!diariesResult.success) {
+						throw new Error("Failed to get user diaries");
+					}
+
+					// 2. 日付順にソート（新しい順）
+					const sortedDiaries = diariesResult.data.sort((a, b) =>
+						b.date.localeCompare(a.date),
+					);
+
+					// 3. 上位count件を取得
+					const recentDiaries = sortedDiaries.slice(0, count);
+
+					logger.info("🤖 get_recent_diaries tool result", {
+						requestedCount: count,
+						actualCount: recentDiaries.length,
+					});
+
+					// 4. 結果を整形
+					return {
+						count: recentDiaries.length,
+						diaries: recentDiaries.map((diary) => ({
+							date: diary.date,
+							feeling: diary.feeling || "記載なし",
+							content: diary.content,
+						})),
+					};
+				} catch (error) {
+					logger.error("🤖 get_recent_diaries tool error", toError(error));
+					throw error;
+				}
+			},
+		}),
+	};
+};

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -41,6 +41,7 @@ Globals:
       - arm64
     Tracing: Active
     Timeout: 180
+    MemorySize: 256
     Environment:
         Variables:
           NODE_ENV: !Ref NodeEnv

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
 
   backend:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.48
+        version: 3.0.48(zod@4.3.5)
       '@aws-lambda-powertools/logger':
         specifier: ^2.30.2
         version: 2.30.2
@@ -45,6 +48,9 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.7.6
         version: 0.7.6(hono@4.11.4)(zod@4.3.5)
+      ai:
+        specifier: ^6.0.141
+        version: 6.0.141(zod@4.3.5)
       aws-jwt-verify:
         specifier: ^5.1.1
         version: 5.1.1
@@ -63,7 +69,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   frontend:
     dependencies:
@@ -105,7 +111,7 @@ importers:
         version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -151,6 +157,28 @@ importers:
         version: 1.4.0
 
 packages:
+
+  '@ai-sdk/gateway@3.0.83':
+    resolution: {integrity: sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.48':
+    resolution: {integrity: sha512-ALmj/53EXpcRqMbGpPJPP4UOSWw0q4VGpnDo7YctvsynjkrKDmoneDG/1a7VQnSPYHnJp6tTRMf5ZdxZ5whulg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.21':
+    resolution: {integrity: sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -910,6 +938,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -1653,6 +1685,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
@@ -1681,6 +1717,12 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  ai@6.0.141:
+    resolution: {integrity: sha512-+GomGQWaId3xN0wcugUW/H7xMMaFkID2PiS7K/Wugj45G3efv0BXhQ3psRZoQVoRbOpdNoUqcK/KTB+FR4h6qg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
@@ -1815,6 +1857,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1913,6 +1959,9 @@ packages:
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -2551,6 +2600,30 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@3.0.83(zod@4.3.5)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.5)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.5
+
+  '@ai-sdk/openai@3.0.48(zod@4.3.5)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.5)
+      zod: 4.3.5
+
+  '@ai-sdk/provider-utils@4.0.21(zod@4.3.5)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.5
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -3844,6 +3917,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.1':
     optional: true
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -4596,6 +4671,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -4634,6 +4711,14 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  ai@6.0.141(zod@4.3.5):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.83(zod@4.3.5)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.5)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.5
 
   aria-hidden@1.2.6:
     dependencies:
@@ -4767,6 +4852,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventsource-parser@3.0.6: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -4854,6 +4941,8 @@ snapshots:
   jiti@2.6.1: {}
 
   js-cookie@3.0.5: {}
+
+  json-schema@0.4.0: {}
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -5275,7 +5364,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -5294,6 +5383,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.1
       '@next/swc-win32-arm64-msvc': 16.1.1
       '@next/swc-win32-x64-msvc': 16.1.1
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5667,7 +5757,7 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vitest@4.0.18(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
@@ -5690,6 +5780,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.0.9
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
- OpenAI Responses API直接呼び出しからVercel AI SDK streamTextに変更
- agentService/diaryToolsを追加しツール呼び出しを自動化
- Lambdaメモリを128MB→256MBに増加（OOM対策）